### PR TITLE
chore: normalize formatting and enforce prettier

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,9 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
     ignore:
-      - dependency-name: "@types/node"
+      - dependency-name: '@types/node'
         versions:
-          - ">=25"
+          - '>=25'
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
+      - run: npm run format
       - run: npm run lint
       - run: npm test -- --runInBand
       - run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,5 +18,6 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
+      - run: npm run format
       - run: npm run all
       - run: git diff --exit-code -- dist/index.js dist/index.js.map dist/licenses.txt

--- a/docs/sarif.md
+++ b/docs/sarif.md
@@ -2,10 +2,10 @@
 
 `deterministic-deps` writes a Markdown report and, by default, a SARIF report under `deterministic-deps-report/` in the scan root.
 
-| Output | Default path | Notes |
-| --- | --- | --- |
-| `report-path` | `deterministic-deps-report/report.md` | Always written. Also summarized in the GitHub Actions job summary. |
-| `sarif-path` | `deterministic-deps-report/deterministic-deps.sarif` | Written when `sarif: true`. Empty when SARIF generation is disabled. |
+| Output        | Default path                                         | Notes                                                                |
+| ------------- | ---------------------------------------------------- | -------------------------------------------------------------------- |
+| `report-path` | `deterministic-deps-report/report.md`                | Always written. Also summarized in the GitHub Actions job summary.   |
+| `sarif-path`  | `deterministic-deps-report/deterministic-deps.sarif` | Written when `sarif: true`. Empty when SARIF generation is disabled. |
 
 Set `sarif: false` to skip SARIF generation. In that case, `sarif-path` is an empty string and any upload step should be guarded.
 


### PR DESCRIPTION
## Summary

Closes #34.

This normalizes the repository files covered by the existing Prettier configuration and makes formatting drift block both pull requests and release validation.

Changes included:

- Ran the existing Prettier write path across the repository using the current ignore policy.
- Preserved intentionally ignored generated/bundled output and Markdown report goldens via the existing `.prettierignore` behavior.
- Added `npm run format` to the CI test job after dependency installation.
- Added `npm run format` to the release validation workflow before the existing full validation command.
- Added `.gitattributes` to force LF text checkouts so Prettier checks behave consistently on Windows, macOS, and Linux runners.
- Accepted Prettier's resulting normalization in `.github/dependabot.yml` and `docs/sarif.md`.

No documentation command or ignore-policy changes were needed.

## Validation

- `npm.cmd run format`
- `npm.cmd run all`
- `git diff --check`
- `git check-attr eol -- .github/workflows/ci.yml src/main.ts README.md`
- Dogfood bundled action:
  - `node dist/index.js`
  - Result: `finding-count=0`, `high=0`, `medium=0`, `low=0`
- GitHub Actions after fix:
  - `ci` run #54: success
  - `codeql` run #54: success