### PR TITLE
ci: add v1 tag smoke workflow

### DIFF
--- a/.github/workflows/v1-tag-smoke.yml
+++ b/.github/workflows/v1-tag-smoke.yml
@@ -1,0 +1,134 @@
+name: v1 tag smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      action-ref:
+        description: Semantic version tag to smoke test before moving v1, for example v1.0.0.
+        required: true
+        default: v1.0.0
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out candidate action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          repository: bjcorder/deterministic-deps
+          ref: ${{ inputs.action-ref }}
+          path: candidate-action
+
+      - name: Prepare smoke fixtures
+        run: |
+          mkdir -p smoke/advisory smoke/enforce smoke/patch smoke/sarif-disabled
+
+          cat > smoke/advisory/package.json <<'JSON'
+          {
+            "name": "advisory-smoke",
+            "version": "1.0.0",
+            "dependencies": {
+              "left-pad": "^1.3.0"
+            }
+          }
+          JSON
+
+          cat > smoke/enforce/package.json <<'JSON'
+          {
+            "name": "enforce-smoke",
+            "version": "1.0.0",
+            "dependencies": {
+              "left-pad": "^1.3.0"
+            }
+          }
+          JSON
+
+          cat > smoke/patch/Cargo.toml <<'TOML'
+          [package]
+          name = "patch-smoke"
+          version = "0.1.0"
+          edition = "2021"
+
+          [dependencies]
+          demo = { git = "https://github.com/example/demo" }
+          TOML
+          touch smoke/patch/Cargo.lock
+
+          cat > smoke/sarif-disabled/README.md <<'MD'
+          # SARIF disabled smoke
+          MD
+
+      - name: Advisory smoke
+        id: advisory
+        uses: ./candidate-action
+        with:
+          path: smoke/advisory
+
+      - name: Validate advisory outputs
+        run: |
+          test "${{ steps.advisory.outputs.finding-count }}" = "2"
+          test "${{ steps.advisory.outputs.high-count }}" = "1"
+          test "${{ steps.advisory.outputs.medium-count }}" = "1"
+          test "${{ steps.advisory.outputs.low-count }}" = "0"
+          test -f "${{ steps.advisory.outputs.report-path }}"
+          test -f "${{ steps.advisory.outputs.sarif-path }}"
+          test -z "${{ steps.advisory.outputs.patch-path }}"
+
+      - name: Enforce smoke
+        id: enforce
+        uses: ./candidate-action
+        continue-on-error: true
+        with:
+          path: smoke/enforce
+          mode: enforce
+          severity-threshold: medium
+
+      - name: Validate enforce outputs
+        run: |
+          test "${{ steps.enforce.outcome }}" = "failure"
+          test "${{ steps.enforce.outputs.finding-count }}" = "2"
+          test "${{ steps.enforce.outputs.high-count }}" = "1"
+          test "${{ steps.enforce.outputs.medium-count }}" = "1"
+          test "${{ steps.enforce.outputs.low-count }}" = "0"
+          test -f "${{ steps.enforce.outputs.report-path }}"
+          test -f "${{ steps.enforce.outputs.sarif-path }}"
+          test -z "${{ steps.enforce.outputs.patch-path }}"
+
+      - name: Patch output smoke
+        id: patch
+        uses: ./candidate-action
+        with:
+          path: smoke/patch
+          sarif: 'false'
+          patch: 'true'
+
+      - name: Validate patch outputs
+        run: |
+          test "${{ steps.patch.outputs.finding-count }}" = "1"
+          test "${{ steps.patch.outputs.high-count }}" = "1"
+          test "${{ steps.patch.outputs.medium-count }}" = "0"
+          test "${{ steps.patch.outputs.low-count }}" = "0"
+          test -f "${{ steps.patch.outputs.report-path }}"
+          test -z "${{ steps.patch.outputs.sarif-path }}"
+          test -s "${{ steps.patch.outputs.patch-path }}"
+
+      - name: SARIF disabled smoke
+        id: sarif-disabled
+        uses: ./candidate-action
+        with:
+          path: smoke/sarif-disabled
+          sarif: 'false'
+
+      - name: Validate SARIF disabled outputs
+        run: |
+          test "${{ steps.sarif-disabled.outputs.finding-count }}" = "0"
+          test "${{ steps.sarif-disabled.outputs.high-count }}" = "0"
+          test "${{ steps.sarif-disabled.outputs.medium-count }}" = "0"
+          test "${{ steps.sarif-disabled.outputs.low-count }}" = "0"
+          test -f "${{ steps.sarif-disabled.outputs.report-path }}"
+          test -z "${{ steps.sarif-disabled.outputs.sarif-path }}"
+          test -z "${{ steps.sarif-disabled.outputs.patch-path }}"
+          test ! -e smoke/sarif-disabled/deterministic-deps-report/deterministic-deps.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+- Added a manual `v1 tag smoke` workflow and release documentation for validating semantic version
+  tags before moving the floating `v1` tag.
+
 ## 0.1.0
 
 - Initial TypeScript GitHub Action implementation.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -9,7 +9,49 @@ This repository publishes a packaged JavaScript action. The bundled `dist/index.
 3. Confirm `git diff --exit-code dist package-lock.json` is clean.
 4. Update `CHANGELOG.md`.
 5. Create a semantic version tag such as `v1.0.0`.
-6. Move or create the major tag, such as `v1`, after validating the release.
+6. Run the `v1 tag smoke` workflow against the semantic version tag.
+7. Move or create the major tag, such as `v1`, after the smoke test passes.
+
+## v1 Tag Smoke Test
+
+Before creating or moving the floating `v1` major tag, validate the exact semantic tag that
+Marketplace users will receive. The smoke test checks out the candidate tag and runs the packaged
+action through GitHub Actions from that checkout, so it validates the committed `dist/` artifact
+without requiring any code changes after the tag exists.
+
+1. Create and push the semantic version tag:
+
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+
+2. Run the `v1 tag smoke` workflow from the Actions tab with `action-ref` set to the semantic tag,
+   for example `v1.0.0`.
+
+   With the GitHub CLI:
+
+   ```bash
+   gh workflow run v1-tag-smoke.yml --ref main -f action-ref=v1.0.0
+   gh run watch
+   ```
+
+3. Confirm the workflow passes. It verifies:
+   - Advisory mode outputs: `finding-count`, severity counts, `report-path`, `sarif-path`, and an
+     empty `patch-path`.
+   - Enforce mode failure behavior with post-step validation still running.
+   - SARIF enabled behavior by checking that a SARIF report path exists.
+   - SARIF disabled behavior by checking that `sarif-path` is empty and no SARIF file is written.
+   - Optional patch output behavior by checking that `patch-path` exists and is non-empty.
+
+4. After the smoke test passes, create or move the `v1` tag to the validated semantic tag:
+
+   ```bash
+   git tag -f v1 v1.0.0
+   git push origin refs/tags/v1 --force
+   ```
+
+Do not move `v1` before the semantic tag smoke test passes.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary

Closes #35.

Adds a manual release-readiness smoke workflow for validating a semantic version tag before creating or moving the floating `v1` tag.

Changes included:

- Added `.github/workflows/v1-tag-smoke.yml` with a `workflow_dispatch` input named `action-ref`.
- The workflow checks out the candidate tag into `candidate-action` and runs it through GitHub Actions via `uses: ./candidate-action`, validating the committed packaged action from the tag without requiring code changes after the tag exists.
- Added smoke cases for:
  - Advisory mode output counts and report paths.
  - Enforce mode failure behavior with `continue-on-error` so post-step output validation still runs.
  - SARIF enabled behavior via a non-empty SARIF output path and existing SARIF file.
  - SARIF disabled behavior via an empty SARIF output path and no SARIF file.
  - Optional patch output behavior via a non-empty patch path and patch file.
- Updated `docs/releasing.md` with the semantic-tag smoke procedure and guidance to move `v1` only after the smoke workflow passes.
- Added an Unreleased changelog entry.

## Validation

- `npm.cmd run format`
- `npm.cmd run all`
- `git diff --check`
- Dogfood bundled action:
  - `node dist/index.js`
  - Result: `finding-count=0`, `high=0`, `medium=0`, `low=0`
- Local fixture sanity checks against `node dist/index.js`:
  - Advisory fixture returned `finding-count=2`, `high-count=1`, `medium-count=1`, `low-count=0`.
  - Patch fixture returned `finding-count=1`, `high-count=1`, `medium-count=0`, `low-count=0`, and a non-empty `patch-path`.