### PR TITLE
docs: align v1 marketplace guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 1.0.0 - 2026-05-03
 
-- Added a manual `v1 tag smoke` workflow and release documentation for validating semantic version
-  tags before moving the floating `v1` tag.
-- Enriched SARIF output with rule descriptions, documentation links, default severity metadata, and
-  stable partial fingerprints for code scanning alerts.
-- Added warning diagnostics for invalid direct action inputs while preserving config/default
-  fallback behavior.
-- Added a machine-readable JSON Schema for `.deterministic-deps.yml` with tests that keep schema
-  values aligned with parser expectations.
+- Published the v1 GitHub Action interface for advisory and enforce modes.
+- Supported static dependency determinism checks for GitHub Actions, container files,
+  Terraform/OpenTofu, Node.js, Python, Go, Rust, JVM, and Ruby.
+- Added Markdown reports, SARIF reports for code scanning, count outputs, and optional patch output
+  for conservative safe exact-line remediation suggestions.
+- Added parser-backed checks for GitHub Actions workflows, Compose files, devcontainer JSON,
+  Terraform/OpenTofu blocks, Node manifests and lockfiles, Python requirements/project files, Go
+  modules, Rust manifests, Gemfiles, and Maven/Gradle files.
+- Added `.deterministic-deps.yml` configuration with rule toggles, severity overrides, allowlists,
+  include/exclude patterns, ecosystem options, and a machine-readable JSON Schema.
+- Added diagnostics for malformed config, invalid config fields, and invalid direct action inputs
+  with deterministic fallback behavior.
+- Added opt-in remote validation for pinned GitHub commit refs with bounded timeout/retry behavior.
+- Added enriched SARIF metadata, rule documentation links, default severity metadata, and stable
+  partial fingerprints for code scanning alerts.
+- Added release validation workflows, including a manual `v1 tag smoke` workflow for validating a
+  semantic version tag before moving the floating `v1` tag.
+- Documented v1 limits: static analysis by default, no package registry resolution, no container
+  digest existence checks, no broad autofix, and remote validation limited to GitHub commit refs.
 
 ## 0.1.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ npm ci
 npm run all
 ```
 
-Rules live in `src/rules.ts`, scanner/reporting code lives under `src/`, and tests live in `__tests__/`.
+Rules live in `src/rules/`, scanner/reporting code lives under `src/`, and tests live in
+`__tests__/`.
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@<full-commit-sha>
-      - uses: bjcorder/deterministic-deps@<full-commit-sha>
+      - uses: bjcorder/deterministic-deps@v1
         with:
           mode: advisory
 ```
@@ -30,7 +30,7 @@ jobs:
 To fail builds once findings are actionable:
 
 ```yaml
-- uses: bjcorder/deterministic-deps@<full-commit-sha>
+- uses: bjcorder/deterministic-deps@v1
   with:
     mode: enforce
     severity-threshold: medium
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - id: deterministic-deps
-        uses: bjcorder/deterministic-deps@<full-commit-sha>
+        uses: bjcorder/deterministic-deps@v1
         with:
           mode: advisory
           sarif: true
@@ -87,7 +87,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - id: deterministic-deps
-        uses: bjcorder/deterministic-deps@<full-commit-sha>
+        uses: bjcorder/deterministic-deps@v1
         continue-on-error: true
         with:
           mode: enforce
@@ -103,7 +103,10 @@ jobs:
         run: exit 1
 ```
 
-`<full-commit-sha>` is a placeholder for the immutable commit you want to run. See [docs/sarif.md](docs/sarif.md) for permissions, private repository notes, and report path details.
+The Marketplace entrypoint is `bjcorder/deterministic-deps@v1`. For workflows that enforce policy,
+pin to the full commit SHA for the validated release behind `v1`. See
+[docs/sarif.md](docs/sarif.md) for permissions, private repository notes, SARIF upload, and report
+path details.
 
 ## Inputs
 

--- a/action.yml
+++ b/action.yml
@@ -1,10 +1,10 @@
 name: Deterministic Deps
 author: Brian Corder
-description: Enforce deterministic dependency declarations across ecosystems.
+description: Detect non-deterministic dependency declarations across ecosystems.
 
 inputs:
   mode:
-    description: Reporting mode. Use advisory to report only, or enforce to fail at the configured severity threshold.
+    description: Reporting mode. Use advisory to report only, or enforce to fail at the configured severity threshold. Defaults to advisory.
     required: false
   path:
     description: Repository path to scan.
@@ -23,22 +23,22 @@ inputs:
     required: false
     default: ''
   severity-threshold:
-    description: Minimum severity that fails the action in enforce mode.
+    description: Minimum severity that fails the action in enforce mode. Defaults to low.
     required: false
   sarif:
-    description: Whether to write a SARIF report.
+    description: Whether to write a SARIF report. Defaults to true.
     required: false
   patch:
-    description: Whether to write a unified diff with safe remediation suggestions.
+    description: Whether to write a unified diff with safe remediation suggestions. Defaults to false.
     required: false
   remote-validation:
-    description: Opt in to remote validation of immutable GitHub commit references.
+    description: Opt in to remote validation of immutable GitHub commit references. Defaults to false.
     required: false
   remote-timeout-ms:
-    description: Per-request timeout for remote validation.
+    description: Per-request timeout for remote validation. Defaults to 5000.
     required: false
   remote-retries:
-    description: Retry count for transient remote validation failures.
+    description: Retry count for transient remote validation failures. Defaults to 1.
     required: false
 
 outputs:

--- a/docs/ecosystems.md
+++ b/docs/ecosystems.md
@@ -1,6 +1,8 @@
 # Ecosystem Notes
 
-The action uses conservative static checks by default. It does not resolve remote refs, inspect package registries, or verify that a digest exists unless explicit remote validation is enabled.
+The action uses conservative static checks by default. It does not resolve remote refs, inspect
+package registries, or verify that container digests exist. Optional remote validation is limited to
+checking pinned GitHub commit refs.
 
 ## SHA and Digest Native Ecosystems
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -6,11 +6,26 @@ This repository publishes a packaged JavaScript action. The bundled `dist/index.
 
 1. Run `npm ci`.
 2. Run `npm run all`.
-3. Confirm `git diff --exit-code dist package-lock.json` is clean.
-4. Update `CHANGELOG.md`.
-5. Create a semantic version tag such as `v1.0.0`.
-6. Run the `v1 tag smoke` workflow against the semantic version tag.
-7. Move or create the major tag, such as `v1`, after the smoke test passes.
+3. Run `npm run format`.
+4. Confirm `git diff --exit-code dist package-lock.json` is clean.
+5. Confirm `git diff --check` is clean.
+6. Update `CHANGELOG.md` with the semantic version being released.
+7. Confirm `action.yml`, `README.md`, and `docs/` describe the same supported inputs, outputs,
+   ecosystems, and v1 limits.
+8. Dogfood the bundled action against this repository and expect zero findings.
+9. Merge the release-prep PR.
+
+## Tagging v1
+
+After the release-prep PR is merged:
+
+1. Check out the validated release commit on `main`.
+2. Create a semantic version tag such as `v1.0.0`.
+3. Push the semantic version tag.
+4. Run the `v1 tag smoke` workflow against the semantic version tag.
+5. Move or create the major tag, such as `v1`, after the smoke test passes.
+
+Do not create or move `v1` before the semantic tag smoke test passes.
 
 ## v1 Tag Smoke Test
 
@@ -52,6 +67,16 @@ without requiring any code changes after the tag exists.
    ```
 
 Do not move `v1` before the semantic tag smoke test passes.
+
+## Release Notes Checklist
+
+The `CHANGELOG.md` entry for a v1 release should identify:
+
+- Supported ecosystems.
+- Advisory and enforce modes.
+- Markdown, SARIF, count, and optional patch outputs.
+- Static-by-default behavior and the opt-in scope of remote validation.
+- Conservative remediation suggestions and known v1 limits.
 
 ## Versioning
 

--- a/docs/sarif.md
+++ b/docs/sarif.md
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - id: deterministic-deps
-        uses: bjcorder/deterministic-deps@<full-commit-sha>
+        uses: bjcorder/deterministic-deps@v1
         with:
           mode: advisory
           sarif: true
@@ -79,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - id: deterministic-deps
-        uses: bjcorder/deterministic-deps@<full-commit-sha>
+        uses: bjcorder/deterministic-deps@v1
         continue-on-error: true
         with:
           mode: enforce
@@ -97,7 +97,9 @@ jobs:
 
 ## Pinning
 
-The examples above pin external actions to full commit SHAs. Replace `<full-commit-sha>` with the immutable commit for the version of `bjcorder/deterministic-deps` you want to run. Tags are convenient for quick experiments, but this project recommends commit SHA pinning for workflows you enforce.
+The examples above use the Marketplace `v1` tag for `deterministic-deps` and pin third-party
+actions to full commit SHAs. For workflows that enforce policy, pin `bjcorder/deterministic-deps` to
+the full commit SHA for the validated release behind `v1`.
 
 ## Private Repositories
 


### PR DESCRIPTION
## Summary

Closes #39.

Performs the final v1 documentation consistency pass before Marketplace publishing.

Changes included:

- Fixed stale contributor docs that still pointed to `src/rules.ts`; rules now point to the current `src/rules/` layout.
- Updated README examples to use the Marketplace `bjcorder/deterministic-deps@v1` entrypoint while retaining full-SHA guidance for enforced policy workflows.
- Updated SARIF docs to match README v1 usage and clarify full-SHA pinning for enforced workflows.
- Tuned `action.yml` Marketplace metadata:
  - action description now reflects advisory detection as well as enforcement
  - config-overridable input descriptions document their runtime defaults without reintroducing metadata defaults
- Replaced the changelog `Unreleased` bucket with a `1.0.0 - 2026-05-03` entry that identifies supported ecosystems, modes, outputs, release validation, and v1 limits.
- Updated release docs to match the actual pre-release flow:
  - run format/all/diff checks
  - dogfood the bundled action
  - merge release-prep work before tagging
  - validate the semantic tag with the `v1 tag smoke` workflow before moving `v1`
- Tightened ecosystem known-limits language so docs do not imply container digest existence checks or broad remote resolution.

## Validation

- `npm.cmd run format`
- `npm.cmd run all`
- `git diff --check`
- Dogfood bundled action:
  - `node dist/index.js`
  - Result: `finding-count=0`, `high=0`, `medium=0`, `low=0`
- Documentation scans confirmed:
  - no remaining `src/rules.ts` references
  - no remaining `bjcorder/deterministic-deps@<full-commit-sha>` placeholders
  - remaining `<full-commit-sha>` guidance only applies to third-party action SHA pinning