### PR TITLE
test: add large repo scanner guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
   partial fingerprints for code scanning alerts.
 - Added release validation workflows, including a manual `v1 tag smoke` workflow for validating a
   semantic version tag before moving the floating `v1` tag.
+- Added scanner guardrail coverage for many dependency files and deeply nested default excludes.
 - Documented v1 limits: static analysis by default, no package registry resolution, no container
   digest existence checks, no broad autofix, and remote validation limited to GitHub commit refs.
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ allowlist:
     ruleId: containers/image-digest
 ```
 
+For large repositories, keep the scan root as narrow as practical and use `include` to target the
+dependency ecosystems you care about. Default excludes already prune common generated and vendor
+directories such as `.git`, `node_modules`, `dist`, `build`, `target`, `.terraform`, virtualenvs,
+and `__pycache__`; add repository-specific generated paths to `exclude` when monorepo tooling writes
+dependencies under other directories.
+
 See [docs/configuration.md](docs/configuration.md) for the full schema.
 
 ## Local Development

--- a/__tests__/scanner.test.ts
+++ b/__tests__/scanner.test.ts
@@ -155,6 +155,39 @@ describe('deterministic-deps scanner', () => {
     expect(allowed.findings).toEqual([])
   })
 
+  it('handles many dependency files while pruning nested default excludes', async () => {
+    const root = tempRepo()
+
+    for (let index = 0; index < 60; index += 1) {
+      write(
+        root,
+        `services/service-${index}/Dockerfile`,
+        `FROM alpine:3.20@sha256:${'a'.repeat(64)}\n`
+      )
+    }
+
+    for (const ignoredDirectory of ['.git', 'node_modules', 'dist', 'target', '.terraform']) {
+      write(
+        root,
+        `platform/${ignoredDirectory}/deeply/nested/package/Dockerfile`,
+        'FROM alpine:latest\n'
+      )
+      write(
+        root,
+        `platform/${ignoredDirectory}/deeply/nested/package/package.json`,
+        JSON.stringify({ dependencies: { leftpad: '^1.0.0' } }, null, 2)
+      )
+    }
+
+    const result = await scan({ root, include: [], exclude: [], config: {} })
+
+    expect(result.scannedFiles).toHaveLength(60)
+    expect(result.scannedFiles).toEqual(
+      Array.from({ length: 60 }, (_, index) => `services/service-${index}/Dockerfile`).sort()
+    )
+    expect(result.findings).toEqual([])
+  })
+
   it('honors ecosystem-specific policy options', async () => {
     const root = tempRepo()
     write(root, 'package.json', JSON.stringify({ dependencies: { leftpad: '^1.0.0' } }, null, 2))

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,6 +73,26 @@ ecosystems:
 
 Allowlist entries should be narrow and temporary. Prefer fixing declarations or adding lockfiles when practical.
 
+## Large Repositories
+
+Default discovery scans supported dependency declaration files and skips common generated or vendor
+directories, including `.git`, `node_modules`, `vendor`, `dist`, `build`, `target`, `.terraform`,
+virtualenvs, and `__pycache__`.
+
+For monorepos, narrow `include` to the ecosystems or package roots you want to evaluate, and add
+repository-specific generated paths to `exclude`. Prefer anchored patterns for known workspace
+layouts, such as:
+
+```yaml
+include:
+  - services/**/package.json
+  - infrastructure/**/*.tf
+
+exclude:
+  - services/**/fixtures/**
+  - tools/generated/**
+```
+
 ## Validation
 
 Malformed YAML fails the action with a clear parse error because the configured policy cannot be trusted. Invalid individual fields emit warnings and are ignored, so the action falls back to defaults or other valid config entries.

--- a/docs/ecosystems.md
+++ b/docs/ecosystems.md
@@ -36,6 +36,11 @@ Gradle Groovy and Kotlin build files are parsed for common dependency and plugin
 
 Projects can tune lockfile and hash requirements with the `ecosystems` config block. This is intended for cases like library repositories that intentionally do not commit application lockfiles, or repositories that accept registry version ranges when a package manager lockfile is present.
 
+Large repositories can also tune discovery with `include` and `exclude`. Default excludes prune
+common generated and vendor directories before evaluation, but monorepos should add generated output
+paths that are specific to their build system and can narrow `include` to the dependency ecosystems
+they actively want to scan.
+
 ## Remediation Suggestions
 
 Reports can include structured remediation suggestions for findings that have a precise replacement. SARIF includes fixes for safe exact-line replacements, and `patch: true` writes those safe replacements to a unified diff without editing source files.


### PR DESCRIPTION
## Summary

Closes #41.

- Added repeatable scanner coverage for a synthetic large-repo shape with many matching dependency files.
- Covered deeply nested ignored directories for `.git`, `node_modules`, `dist`, `target`, and `.terraform` with intentionally bad dependency declarations to verify default excludes prune them before evaluation.
- Kept the guardrail non-timing-based so normal test runs do not become flaky.
- Documented large-repository tuning guidance for narrowing scan scope with `include` and adding generated paths to `exclude`.
- Updated README, configuration docs, ecosystem notes, and changelog.

## Validation

- `npm.cmd test -- --runInBand __tests__/scanner.test.ts`
- `npm.cmd run format`
- `npm.cmd run all`
- `git diff --check`
- Dogfood bundled action with `node dist/index.js` using `GITHUB_WORKSPACE` and `GITHUB_STEP_SUMMARY`; result: 0 findings.