### PR TITLE
docs: prepare v1 marketplace release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - run: npm run lint
       - run: npm test -- --runInBand
       - run: npm run build
+      - run: npm run audit
 
   dist:
     name: check dist
@@ -41,6 +42,7 @@ jobs:
       - run: npm ci
       - run: npm run bundle
       - run: git diff --exit-code -- dist/index.js dist/index.js.map dist/licenses.txt
+      - run: git diff --check
 
   local-action:
     name: test local action

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,5 +19,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run format
+      - run: npm run audit
       - run: npm run all
       - run: git diff --exit-code -- dist/index.js dist/index.js.map dist/licenses.txt
+      - run: git diff --check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## 1.0.0 - 2026-05-03
 
 - Published the v1 GitHub Action interface for advisory and enforce modes.
+- Set package and action metadata for the stable Marketplace `v1.0.0` release.
 - Supported static dependency determinism checks for GitHub Actions, container files,
   Terraform/OpenTofu, Node.js, Python, Go, Rust, JVM, and Ruby.
 - Added Markdown reports, SARIF reports for code scanning, count outputs, and optional patch output
@@ -23,6 +24,7 @@ All notable changes to this project will be documented in this file.
   partial fingerprints for code scanning alerts.
 - Added release validation workflows, including a manual `v1 tag smoke` workflow for validating a
   semantic version tag before moving the floating `v1` tag.
+- Added release-readiness audit and whitespace checks to CI and release validation.
 - Added scanner guardrail coverage for many dependency files and deeply nested default excludes.
 - Documented v1 limits: static analysis by default, no package registry resolution, no container
   digest existence checks, no broad autofix, and remote validation limited to GitHub commit refs.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,19 @@ inputs; and non-negative integers for remote timeout and retry inputs.
 
 ## Supported Ecosystems
 
-V1 scans GitHub Actions, Docker and Compose files, devcontainers, Terraform/OpenTofu, npm/Yarn/pnpm, Python, Go, Rust, Maven/Gradle, and Ruby. See [docs/ecosystems.md](docs/ecosystems.md) and [docs/rules.md](docs/rules.md) for the rule catalog.
+| Ecosystem              | V1 coverage                                                                                    |
+| ---------------------- | ---------------------------------------------------------------------------------------------- |
+| GitHub Actions         | Workflow and action `uses:` refs, reusable workflows, and `docker://` action image references. |
+| Containers             | Dockerfiles, Docker Compose files, and devcontainer image references.                          |
+| Terraform and OpenTofu | Git module refs, provider constraints, and `.terraform.lock.hcl` coverage.                     |
+| Node.js                | npm, Yarn, and pnpm manifests and lockfiles.                                                   |
+| Python                 | `requirements*.txt`, `pyproject.toml`, Pipfile, Poetry, uv, and Pipenv lockfile coverage.      |
+| Go                     | `go.mod`, `go.sum`, and git-like replacement refs.                                             |
+| Rust                   | `Cargo.toml`, `Cargo.lock`, and git dependency revisions.                                      |
+| JVM                    | Maven `pom.xml`, Gradle Groovy/Kotlin builds, and Gradle lock or verification metadata.        |
+| Ruby                   | Gemfile dependency refs and `Gemfile.lock` coverage.                                           |
+
+See [docs/ecosystems.md](docs/ecosystems.md) and [docs/rules.md](docs/rules.md) for the full rule catalog.
 
 ## Remote Validation
 
@@ -192,6 +204,18 @@ and `__pycache__`; add repository-specific generated paths to `exclude` when mon
 dependencies under other directories.
 
 See [docs/configuration.md](docs/configuration.md) for the full schema.
+
+## V1 Known Limits
+
+- Static analysis is the default. The action does not resolve package registries, clone dependency
+  sources, or inspect dependency graph APIs.
+- Remote validation is explicit opt-in and limited to immutable GitHub.com or GitHub Enterprise
+  Server commit refs.
+- Container image digest syntax is checked locally, but registry digest existence is not validated.
+- Remediation suggestions are conservative and only produce patches when the deterministic
+  replacement is already present in the scanned source.
+- Parser coverage is intentionally focused on common dependency declarations; use `allowlist`,
+  `rules`, and `ecosystems` configuration for repository-specific policy exceptions.
 
 ## Local Development
 

--- a/action.yml
+++ b/action.yml
@@ -1,11 +1,12 @@
 name: Deterministic Deps
 author: Brian Corder
-description: Detect non-deterministic dependency declarations across ecosystems.
+description: Static dependency determinism scanner for GitHub Actions, containers, IaC, and package manifests.
 
 inputs:
   mode:
     description: Reporting mode. Use advisory to report only, or enforce to fail at the configured severity threshold. Defaults to advisory.
     required: false
+    default: advisory
   path:
     description: Repository path to scan.
     required: false
@@ -25,21 +26,27 @@ inputs:
   severity-threshold:
     description: Minimum severity that fails the action in enforce mode. Defaults to low.
     required: false
+    default: low
   sarif:
     description: Whether to write a SARIF report. Defaults to true.
     required: false
+    default: 'true'
   patch:
     description: Whether to write a unified diff with safe remediation suggestions. Defaults to false.
     required: false
+    default: 'false'
   remote-validation:
     description: Opt in to remote validation of immutable GitHub commit references. Defaults to false.
     required: false
+    default: 'false'
   remote-timeout-ms:
     description: Per-request timeout for remote validation. Defaults to 5000.
     required: false
+    default: '5000'
   remote-retries:
     description: Retry count for transient remote validation failures. Defaults to 1.
     required: false
+    default: '1'
 
 outputs:
   finding-count:

--- a/docs/release-notes-v1.md
+++ b/docs/release-notes-v1.md
@@ -1,0 +1,44 @@
+# v1.0.0 Release Notes
+
+`deterministic-deps` v1.0.0 is the first stable Marketplace-ready release of the packaged GitHub
+Action.
+
+## Highlights
+
+- Advisory mode by default, with enforce mode available when projects are ready to fail CI.
+- Static dependency determinism checks for GitHub Actions, container files, devcontainers,
+  Terraform/OpenTofu, Node.js, Python, Go, Rust, JVM, and Ruby.
+- Markdown reports, SARIF reports for GitHub code scanning, severity count outputs, and optional
+  patch output for conservative safe exact-line remediation suggestions.
+- Parser-backed checks for common YAML, JSON, TOML, HCL, XML, Gradle, and package manifest formats.
+- `.deterministic-deps.yml` configuration for rule toggles, severity overrides, allowlists,
+  include/exclude patterns, ecosystem options, and editor validation through the published JSON
+  Schema.
+- Opt-in remote validation for pinned GitHub.com and GitHub Enterprise Server commit refs with
+  bounded timeout and retry behavior.
+- Release validation for stale `dist/`, formatting, tests, type checking, CodeQL, audit checks, and
+  packaged action smoke tests before moving the floating `v1` tag.
+
+## Outputs
+
+- `finding-count`
+- `high-count`
+- `medium-count`
+- `low-count`
+- `report-path`
+- `sarif-path`
+- `patch-path`
+
+## Known Limits
+
+- Static analysis is the default; package registries, dependency graph APIs, and source repositories
+  are not resolved.
+- Remote validation is opt in and limited to immutable GitHub commit refs.
+- Container image digest existence is not checked against registries.
+- Patch output is intentionally narrow and only includes high-confidence exact-line replacements.
+- Parser coverage focuses on common dependency declaration shapes for v1.
+
+## Release Blockers
+
+No open blocker issues are required for a v1 advisory-mode release after the release checklist and
+`v1 tag smoke` workflow pass.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,15 +5,18 @@ This repository publishes a packaged JavaScript action. The bundled `dist/index.
 ## Release Checklist
 
 1. Run `npm ci`.
-2. Run `npm run all`.
-3. Run `npm run format`.
-4. Confirm `git diff --exit-code dist package-lock.json` is clean.
-5. Confirm `git diff --check` is clean.
-6. Update `CHANGELOG.md` with the semantic version being released.
-7. Confirm `action.yml`, `README.md`, and `docs/` describe the same supported inputs, outputs,
+2. Run `npm run format`.
+3. Run `npm run audit`.
+4. Run `npm run all`.
+5. Confirm `git diff --exit-code -- dist/index.js dist/index.js.map dist/licenses.txt` is clean.
+6. Confirm `git diff --check` is clean.
+7. Update `CHANGELOG.md` and `docs/release-notes-v1.md` with the semantic version being released.
+8. Confirm `action.yml`, `README.md`, and `docs/` describe the same supported inputs, outputs,
    ecosystems, and v1 limits.
-8. Dogfood the bundled action against this repository and expect zero findings.
-9. Merge the release-prep PR.
+9. Confirm no open blocker issues are required for an advisory-mode v1 release, or list them in the
+   release notes before tagging.
+10. Dogfood the bundled action against this repository and expect zero findings.
+11. Merge the release-prep PR.
 
 ## Tagging v1
 
@@ -77,6 +80,10 @@ The `CHANGELOG.md` entry for a v1 release should identify:
 - Markdown, SARIF, count, and optional patch outputs.
 - Static-by-default behavior and the opt-in scope of remote validation.
 - Conservative remediation suggestions and known v1 limits.
+- Whether there are any open blocker issues for an advisory-mode release.
+
+Use [`release-notes-v1.md`](release-notes-v1.md) as the maintainer-facing release notes source for
+the initial `v1.0.0` GitHub release.
 
 ## Versioning
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deterministic-deps",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deterministic-deps",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deterministic-deps",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "description": "GitHub Action to enforce deterministic dependency declarations across ecosystems.",
   "main": "dist/index.js",
@@ -11,6 +11,7 @@
     "format:write": "prettier --write .",
     "lint": "eslint .",
     "test": "jest --coverage --runInBand",
+    "audit": "npm audit --audit-level=high",
     "all": "npm run lint && npm run test && npm run build && npm run bundle"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

Closes #23.

- Set package metadata to `1.0.0` and made `action.yml` Marketplace metadata/defaults explicit for the stable `v1` release.
- Expanded the README supported ecosystem section into a v1 coverage table and added prominent v1 known limitations.
- Added `docs/release-notes-v1.md` as a maintainer-facing release notes source, including outputs, limits, and the no-open-blocker statement for advisory-mode v1.
- Tightened `docs/releasing.md` so maintainers can publish `v1.0.0` without guessing: audit, dist freshness, whitespace checks, release notes, blocker check, dogfood, semantic tag smoke, then moving `v1`.
- Added `npm run audit` and wired audit/whitespace validation into CI and release validation while keeping existing dist freshness checks.
- Updated the changelog for the stable Marketplace release readiness work.

## Validation

- `npm.cmd run format`
- `npm.cmd run audit`
- `npm.cmd run all`
- `git diff --exit-code -- dist/index.js dist/index.js.map dist/licenses.txt`
- `git diff --check`
- Dogfood bundled action with `node dist/index.js` using `GITHUB_WORKSPACE` and `GITHUB_STEP_SUMMARY`; result: 0 findings.