### PR TITLE
docs: add contributor license agreement

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,194 @@
+# Contributor License Agreement
+
+Version 1.0
+
+Maintainer note: this is a draft agreement for review by qualified legal counsel before it is
+enforced. If Ozark Security Labs is incorporated or the project is transferred to another legal
+entity, update the Project Steward definition before collecting signatures.
+
+This Contributor License Agreement ("Agreement") governs Contributions submitted to
+`deterministic-deps`.
+
+## 1. Definitions
+
+"Project" means `deterministic-deps`, including its source code, documentation, tests, examples,
+release artifacts, and related project materials.
+
+"Project Steward" means Ozark Security Labs, the maintainer organization for the Project, and any
+legal successor, assignee, or entity designated by the Project Steward to maintain or commercialize
+the Project.
+
+"You" or "Your" means the individual or legal entity submitting a Contribution. If You are signing
+on behalf of a legal entity, "You" includes that entity and any affiliates that own, control, or have
+the right to license the Contribution.
+
+"Contribution" means any original work of authorship, source code, object code, documentation,
+tests, configuration, design material, issue attachment, pull request, commit, patch, or other
+material that You intentionally submit to the Project for inclusion. "Submitted" means any form of
+electronic, verbal, or written communication sent to the Project Steward or to a Project-managed
+repository, issue tracker, pull request, mailing list, chat, or similar collaboration channel. A
+communication is not a Contribution if You clearly mark it as "Not a Contribution" or if it is a
+general question, bug report, support request, or discussion that does not provide material intended
+for inclusion in the Project.
+
+"Project License" means any open source license under which the Project Steward distributes the
+Project, including future versions of that license when the Project Steward chooses to adopt them.
+
+## 2. Copyright License
+
+You retain ownership of Your Contributions.
+
+Subject to this Agreement, You grant the Project Steward a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of,
+publicly display, publicly perform, distribute, sublicense, relicense, make available, and otherwise
+use Your Contributions, including derivative works of Your Contributions, in source or object form.
+
+This license allows the Project Steward to distribute Your Contributions under the Project License,
+under future Project licenses, and under separate commercial or proprietary license terms. This
+license also allows the Project Steward to grant downstream users and commercial customers the rights
+needed to use, modify, distribute, and sublicense the Project and Your Contributions as part of the
+Project.
+
+## 3. Patent License
+
+Subject to this Agreement, You grant the Project Steward and recipients of the Project a perpetual,
+worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made,
+use, offer to sell, sell, import, and otherwise transfer Your Contributions, alone or in combination
+with the Project.
+
+This patent license applies only to patent claims that You own or control and that would necessarily
+be infringed by Your Contributions or by the combination of Your Contributions with the Project as
+submitted.
+
+If You or Your affiliates initiate patent litigation claiming that the Project or a Contribution
+submitted to the Project infringes a patent, any patent licenses granted to You under this Agreement
+for the Project terminate as of the date the litigation is filed.
+
+## 4. Moral Rights and Similar Rights
+
+To the fullest extent permitted by law, You waive and agree not to assert moral rights, rights of
+attribution, rights of integrity, or similar rights that would interfere with the Project Steward's
+exercise of the licenses granted in this Agreement. If those rights cannot be waived, You grant the
+Project Steward the broadest license and consent necessary to exercise the rights granted in this
+Agreement.
+
+## 5. Contributor Representations
+
+You represent that:
+
+- You have the legal authority to enter into this Agreement.
+- You own or have sufficient rights to license Your Contributions under this Agreement.
+- Your Contributions are original to You, except for third-party material that You clearly identify
+  in writing when submitting the Contribution.
+- Your submission of the Contribution does not violate any employment agreement, contractor
+  agreement, confidentiality obligation, open source license, or other obligation that applies to
+  You.
+- If Your employer, client, school, or another party may own or control rights in Your Contribution,
+  You have obtained permission to submit the Contribution under this Agreement.
+- Your Contributions do not knowingly include malicious code, intentionally hidden behavior, or code
+  designed to bypass security controls.
+
+If You become aware that any representation above is inaccurate, You will promptly notify the Project
+Steward.
+
+## 6. Third-Party Material
+
+Do not submit third-party code, documentation, generated output, data, or other material unless You
+have the right to submit it under this Agreement and the material is compatible with the Project's
+licensing goals. When submitting third-party material, identify its source, license, and any required
+notices in the pull request or accompanying contribution notes.
+
+The Project Steward may decline, remove, rewrite, or request changes to any Contribution that creates
+licensing, provenance, security, or maintenance concerns.
+
+## 7. No Obligation
+
+The Project Steward is not required to accept, use, publish, maintain, support, or distribute any
+Contribution.
+
+## 8. Disclaimer
+
+YOUR CONTRIBUTIONS ARE PROVIDED "AS IS", WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, WHETHER
+EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT.
+
+TO THE FULLEST EXTENT PERMITTED BY LAW, NEITHER YOU NOR THE PROJECT STEWARD WILL BE LIABLE TO THE
+OTHER FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES ARISING
+OUT OF THIS AGREEMENT OR ANY CONTRIBUTION.
+
+## 9. Entity Contributors
+
+If You are signing on behalf of an entity, You represent that You have authority to bind that entity
+to this Agreement. The entity agrees that Contributions submitted by its employees, contractors, or
+agents are covered by this Agreement when those Contributions are submitted within the scope of their
+work for the entity or using intellectual property owned or controlled by the entity.
+
+If You are an individual contributing work that may be owned by Your employer or client, do not rely
+on this individual agreement alone. The Project Steward may require a signed entity agreement or
+written authorization before accepting the Contribution.
+
+## 10. Assignment
+
+The Project Steward may assign this Agreement to a successor, affiliate, acquirer, or other entity
+that assumes responsibility for maintaining, distributing, commercializing, or enforcing rights in the
+Project. You may assign this Agreement only with the Project Steward's written consent, except to an
+entity that succeeds to substantially all of Your relevant assets or business and agrees to be bound
+by this Agreement.
+
+## 11. Governing Law
+
+This Agreement is governed by the laws of the State of Missouri, USA, without regard to its
+conflict-of-laws rules. The United Nations Convention on Contracts for the International Sale of
+Goods does not apply.
+
+## 12. Entire Agreement
+
+This Agreement is the complete agreement between You and the Project Steward regarding Your
+Contributions. It does not replace any separate written agreement signed by You and the Project
+Steward. If any provision is unenforceable, the remaining provisions remain in effect.
+
+## 13. How to Agree
+
+The Project Steward may accept this Agreement through an electronic signature service, a CLA bot, a
+signed document, or a clear written acknowledgement in a pull request or issue.
+
+Suggested acknowledgement:
+
+```text
+I have read and agree to the deterministic-deps Contributor License Agreement version 1.0.
+```
+
+Signed CLA records may contain personal information and should be stored privately, not committed to
+the public repository.
+
+## Individual Signature
+
+Full legal name:
+
+GitHub username:
+
+Email:
+
+Employer or affiliation, if relevant:
+
+I am signing as an individual and have authority to submit my Contributions under this Agreement.
+
+Signature:
+
+Date:
+
+## Entity Signature
+
+Legal entity name:
+
+Authorized signer name and title:
+
+GitHub organization or usernames covered, if applicable:
+
+Email:
+
+The signer represents that they have authority to bind the entity to this Agreement.
+
+Signature:
+
+Date:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,20 @@
 
 Thanks for helping make dependency declarations more deterministic.
 
+## Contributor License Agreement
+
+Non-trivial contributions require agreement to the [Contributor License Agreement](CLA.md) before
+they can be merged. The CLA lets contributors keep ownership of their work while granting the
+project steward the rights needed to maintain the project, distribute it under open source licenses,
+and offer commercial licenses for proprietary embedding.
+
+If your employer or client may own your contribution, get written permission before submitting it.
+Maintainers may request an entity agreement or other authorization for company-owned work.
+
+Until an automated CLA check is configured, maintainers may ask contributors to acknowledge the CLA
+in a pull request comment. Signed CLA records may contain personal information and should not be
+committed to this repository.
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## Summary

- Add a draft Contributor License Agreement with individual and entity signing paths.
- Grant the project steward rights needed for open source distribution and commercial licensing while contributors retain ownership.
- Update contribution guidance to require CLA acknowledgement for non-trivial contributions and avoid committing signed records with personal data.

## Notes

This CLA is intentionally marked as a draft for legal review before enforcement, especially once Ozark Security Labs has a finalized legal entity.

## Verification

- `npm run all`
- `npm run format`
- `git diff --check`