### PR TITLE
chore: prepare v1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 1.1.0 - 2026-05-13
 
 - Added a GitHub Actions runner-label rule that flags floating hosted labels such as
   `ubuntu-latest`, `windows-latest`, and `macos-latest`.

--- a/docs/release-notes-v1.md
+++ b/docs/release-notes-v1.md
@@ -1,26 +1,32 @@
-# v1.0.0 Release Notes
+# v1.1.0 Release Notes
 
-`deterministic-deps` v1.0.0 is the first stable Marketplace-ready release of the packaged GitHub
-Action.
+`deterministic-deps` v1.1.0 adds new deterministic checks for GitHub Actions runners and Rust
+toolchain files, hardens credential redaction, and restricts remote-validation token forwarding.
 
 - Marketplace: <https://github.com/marketplace/actions/deterministic-deps>
-- Release: <https://github.com/Ozark-Security-Labs/deterministic-deps/releases/tag/v1.0.0>
+- Release: <https://github.com/Ozark-Security-Labs/deterministic-deps/releases/tag/v1.1.0>
 
 ## Highlights
 
-- Advisory mode by default, with enforce mode available when projects are ready to fail CI.
-- Static dependency determinism checks for GitHub Actions, container files, devcontainers,
-  Terraform/OpenTofu, Node.js, Python, Go, Rust, JVM, and Ruby.
-- Markdown reports, SARIF reports for GitHub code scanning, severity count outputs, and optional
-  patch output for conservative safe exact-line remediation suggestions.
-- Parser-backed checks for common YAML, JSON, TOML, HCL, XML, Gradle, and package manifest formats.
-- `.deterministic-deps.yml` configuration for rule toggles, severity overrides, allowlists,
-  include/exclude patterns, ecosystem options, and editor validation through the published JSON
-  Schema.
-- Opt-in remote validation for pinned GitHub.com and GitHub Enterprise Server commit refs with
-  bounded timeout and retry behavior.
-- Release validation for stale `dist/`, formatting, tests, type checking, CodeQL, audit checks, and
-  packaged action smoke tests before moving the floating `v1` tag.
+- Added `github-actions/versioned-runner` to flag floating GitHub-hosted runner labels:
+  `ubuntu-latest`, `windows-latest`, and `macos-latest`.
+- Added `rust/toolchain-version` to flag floating Rust channels in `rust-toolchain.toml` and
+  legacy `rust-toolchain` files.
+- Redacted credential-bearing dependency strings from findings, annotations, Markdown reports,
+  SARIF results, summaries, and suggestion text.
+- Suppressed SARIF fixes and patch hunks when replacement text contains credential material.
+- Added `remote-token-policy`, defaulting to trusted-host `auto`, so `GITHUB_TOKEN` is sent only to
+  trusted HTTPS GitHub API hosts during opt-in remote validation. Use `never` for fully
+  unauthenticated remote validation.
+- Updated this repository's workflows and examples to use versioned hosted runner labels while
+  preserving static-by-default scanner behavior.
+
+## Issues Closed
+
+- #69: Versioned GitHub Actions runner labels.
+- #70: Deterministic Rust toolchain files.
+- #77: Redact credentials from user-visible findings.
+- #78: Restrict remote-validation token forwarding to trusted GitHub API hosts.
 
 ## Outputs
 
@@ -38,10 +44,11 @@ Action.
   are not resolved.
 - Remote validation is opt in and limited to immutable GitHub commit refs.
 - Container image digest existence is not checked against registries.
-- Patch output is intentionally narrow and only includes high-confidence exact-line replacements.
+- Patch output is intentionally narrow and only includes high-confidence exact-line replacements
+  that are not credential-bearing.
 - Parser coverage focuses on common dependency declaration shapes for v1.
 
 ## Release Blockers
 
-No open blocker issues are required for a v1 advisory-mode release after the release checklist and
-`v1 tag smoke` workflow pass.
+No open blocker issues are required for this advisory-mode v1 release after the release checklist
+and `v1 tag smoke` workflow pass.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deterministic-deps",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deterministic-deps",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@actions/core": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deterministic-deps",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "GitHub Action to enforce deterministic dependency declarations across ecosystems.",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Prepare v1.1.0 release metadata after merging the milestone hardening work.
- Move the current changelog notes into `1.1.0 - 2026-05-13`.
- Refresh v1 release notes for the new rules, redaction hardening, and remote token policy.
- Bump private package metadata to `1.1.0` for release consistency.

## Tests

- [x] `npm run all`
- [x] `npm run format`
- [x] `git diff --check`
- [x] Source behavior changes include updated `dist/`
- [x] Public behavior changes include docs/changelog updates

## Security

- [x] Dependency or workflow changes are pinned deterministically
- [x] Scanner changes preserve offline static analysis by default
- [x] New or changed findings include conservative fixtures/tests

## Notes

Release checklist also completed locally:

- `npm.cmd run audit`
- `git diff --exit-code -- dist/index.js dist/index.js.map dist/licenses.txt`
- Dogfood `node dist\\index.js` returned `finding-count=0`

This PR contains only release metadata/package version updates for publishing `v1.1.0`.
