### PR TITLE
[codex] docs: add branded README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
-# deterministic-deps
+<p align="center">
+  <img src="docs/assets/deterministic-deps-banner.svg" alt="deterministic-deps" width="640">
+</p>
+
+<p align="center"><strong>Static dependency determinism scanning for GitHub Actions, containers, IaC, and package manifests.</strong></p>
+
+<p align="center">
+  <a href="https://github.com/Ozark-Security-Labs/deterministic-deps/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/Ozark-Security-Labs/deterministic-deps/actions/workflows/ci.yml/badge.svg?branch=main"></a>
+  <a href="https://github.com/Ozark-Security-Labs/deterministic-deps/actions/workflows/security-hygiene.yml"><img alt="Security hygiene" src="https://github.com/Ozark-Security-Labs/deterministic-deps/actions/workflows/security-hygiene.yml/badge.svg?branch=main"></a>
+  <a href="https://github.com/Ozark-Security-Labs/deterministic-deps/actions/workflows/codeql.yml"><img alt="CodeQL" src="https://github.com/Ozark-Security-Labs/deterministic-deps/actions/workflows/codeql.yml/badge.svg?branch=main"></a>
+  <a href="LICENSE"><img alt="License: AGPL-3.0-only" src="https://img.shields.io/badge/license-AGPL--3.0--only-blue.svg"></a>
+  <img alt="Node 24+" src="https://img.shields.io/badge/node-24%2B-5FA04E.svg">
+  <a href="https://github.com/Ozark-Security-Labs/deterministic-deps/releases"><img alt="Latest release" src="https://img.shields.io/github/v/release/Ozark-Security-Labs/deterministic-deps?sort=semver&display_name=tag"></a>
+</p>
+
+---
 
 `deterministic-deps` is a GitHub Action that reports dependency declarations that can drift over time. It is language-agnostic, works by static analysis only, and favors SHA, digest, hash, exact-version, and lockfile based determinism.
 

--- a/docs/assets/deterministic-deps-banner.svg
+++ b/docs/assets/deterministic-deps-banner.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 200" role="img" aria-label="deterministic-deps">
+  <title>deterministic-deps</title>
+  <desc>deterministic-deps: static dependency determinism scanner</desc>
+  <rect width="720" height="200" rx="12" fill="#0b1220"/>
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace">
+    <text x="48" y="104" font-size="52" font-weight="700" fill="#e2e8f0">deterministic</text>
+    <text x="454" y="104" font-size="52" font-weight="700" fill="#38bdf8">-deps</text>
+    <text x="48" y="148" font-size="18" fill="#94a3b8">static dependency determinism scanner</text>
+  </g>
+  <g transform="translate(646, 54)">
+    <circle r="10" fill="#22c55e"/>
+    <path d="M-4 0l3 3 6-7" fill="none" stroke="#0b1220" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle r="10" cy="36" fill="#38bdf8"/>
+    <path d="M0 28v16M-6 36h12" fill="none" stroke="#0b1220" stroke-width="2.5" stroke-linecap="round"/>
+    <circle r="10" cy="72" fill="#f59e0b"/>
+    <path d="M-4 72h8M0 68v8" fill="none" stroke="#0b1220" stroke-width="2.5" stroke-linecap="round"/>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Add an AuthMap-inspired centered README banner for deterministic-deps.
- Add README badges for CI, security hygiene, CodeQL, license, Node runtime, and latest release.
- Commit the new SVG asset under `docs/assets/`.

## Test Plan
- `npm run format`
- `git diff --check`
- `npm test -- --runInBand`